### PR TITLE
add a subpoint to instructions for M1 chip users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Uses the default Flask development server.
 
 1. Rename *.env.dev-sample* to *.env.dev*.
 1. Update the environment variables in the *docker-compose.yml* and *.env.dev* files.
+    - (M1 chip only) Remove `-slim-buster` from the Python dependency in `services/web/Dockerfile` to suppress an issue with installing psycopg2
 1. Build the images and run the containers:
 
     ```sh


### PR DESCRIPTION
While I was following the guide over at https://testdriven.io/blog/dockerizing-flask-with-postgres-gunicorn-and-nginx/, I ran into an issue unique to M1 chip macs, where psycopg2 dependency would snag the docker-compose command. Using a non-slim version of python resolved the issue. Alternative, more verbose solutions can be found here: 
https://github.com/psycopg/psycopg2/issues/1200

