### PR TITLE
Update pinned version of flask-sqlalchemy.

### DIFF
--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.2.2
-Flask-SQLAlchemy==2.5.1
+Flask-SQLAlchemy==3.0.2
 gunicorn==20.1.0
 psycopg2-binary==2.9.4


### PR DESCRIPTION
On build, the original version gets error:
`AttributeError: module 'sqlalchemy' has no attribute '__all__'`

This PR updates Flask-SQLAlchemy from v2.5.1 to v3.0.2

See this issue: https://github.com/pallets-eco/flask-sqlalchemy/issues/1122